### PR TITLE
Change specific convert for Eloquent to generic Arrayable

### DIFF
--- a/src/CamelCaseJsonResponseFactory.php
+++ b/src/CamelCaseJsonResponseFactory.php
@@ -2,7 +2,6 @@
 namespace Grohiro\LaravelCamelCaseJson;
 
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Routing\ResponseFactory as BaseResponseFactory;
 
 /**
@@ -26,27 +25,13 @@ class CamelCaseJsonResponseFactory extends BaseResponseFactory
      */
     public function encodeJson($value)
     {
-        if ($value instanceof Collection) {
-            return $this->encodeCollection($value);
-        } else if ($value instanceof Arrayable) {
+        if ($value instanceof Arrayable) {
             return $this->encodeArrayable($value);
         } else if (is_array($value)) {
             return $this->encodeArray($value);
         } else {
             return $value;
         }
-    }
-
-    /**
-     * Encode a collection
-     */
-    public function encodeCollection($collection)
-    {
-        $items = [];
-        foreach ($collection as $item) {
-            $items[] = $this->encodeJson($item);
-        }
-        return $items;
     }
 
     /**

--- a/src/CamelCaseJsonResponseFactory.php
+++ b/src/CamelCaseJsonResponseFactory.php
@@ -1,8 +1,8 @@
 <?php
 namespace Grohiro\LaravelCamelCaseJson;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\ResponseFactory as BaseResponseFactory;
 
 /**
@@ -28,8 +28,8 @@ class CamelCaseJsonResponseFactory extends BaseResponseFactory
     {
         if ($value instanceof Collection) {
             return $this->encodeCollection($value);
-        } else if ($value instanceof Model) {
-            return $this->encodeModel($value);
+        } else if ($value instanceof Arrayable) {
+            return $this->encodeArrayable($value);
         } else if (is_array($value)) {
             return $this->encodeArray($value);
         } else {
@@ -50,11 +50,11 @@ class CamelCaseJsonResponseFactory extends BaseResponseFactory
     }
 
     /**
-     * Encode a model
+     * Encode a arrayable
      */
-    public function encodeModel($model)
+    public function encodeArrayable($arrayable)
     {
-        $array = $model->toArray();
+        $array = $arrayable->toArray();
         return $this->encodeJson($array);
     }
 


### PR DESCRIPTION
This pull request make other thing (like paginator) can convert to camel case too.

class Collection and Model is Arrayable. so we can use method to convert to array.